### PR TITLE
Fix/method existence check

### DIFF
--- a/includes/trait-export.php
+++ b/includes/trait-export.php
@@ -65,17 +65,30 @@ trait WPB_Menu_Export {
 						$export_item['url'] = $item->url;
 						break;
 					case 'post_type':
-						$post                     = get_post( $item->object_id );
-						$export_item['page']      = $post->post_name;
-						$export_item['post_type'] = $post->post_type;
+						$post = get_post( $item->object_id );
+						if ( $post ) {
+							$export_item['page']      = $post->post_name;
+							$export_item['post_type'] = $post->post_type;
+						} else {
+							WP_CLI::warning( 'The post object for menu item "' . $item->title . '" could not be found.' );
+							continue 2;
+						}
 						break;
 					case 'taxonomy':
-						$term                    = get_term( $item->object_id, $item->object );
-						$export_item['taxonomy'] = $term->taxonomy;
-						$export_item['term']     = $term->term_id;
+						$term = get_term( $item->object_id, $item->object );
+						if ( $term && ! is_wp_error( $term ) ) {
+							$export_item['taxonomy'] = $term->taxonomy;
+							$export_item['term']     = $term->term_id;
+						} else {
+							WP_CLI::warning( 'The taxonomy term for menu item "' . $item->title . '" could not be found.' );
+							continue 2;
+						}
 						break;
+					default:
+						WP_CLI::warning( 'Unknown menu item type "' . $item->type . '" for menu item "' . $item->title . '". The element will be skipped.' );
+						continue 2;
 				}
-
+			
 				$export_menu['items'][] = $export_item;
 			}
 

--- a/includes/trait-import.php
+++ b/includes/trait-import.php
@@ -49,12 +49,19 @@ trait WPB_Menu_Import {
 		}
 
 		foreach ( $menu['items'] as $menu_item ) {
-			$get_method          = 'get_menu_data_by_' . $menu_item['type'];
 			$menu_data_defaults  = array(
 				'menu-item-title'  => isset( $menu_item['title'] ) ? $menu_item['title'] : false,
 				'menu-item-status' => 'publish',
 			);
-			$menu_data_raw       = $this->$get_method( $menu_item, $menu_data_defaults );
+
+			$get_method = 'get_menu_data_by_' . $menu_item['type'];
+
+			if ( method_exists( $this, $get_method ) ) {
+				$menu_data_raw = $this->$get_method( $menu_item, $menu_data_defaults );
+			} else {
+				WP_CLI::log( 'The submenu type "' . $menu_item['type'] . '" is not supported. The menu item "' . $menu_item['title'] . '" will be skipped.' );
+				continue;
+			}
 
 			if ( empty( $menu_data_raw ) ) {
 				WP_CLI::log( 'The submenu item "' . $menu_item['title'] . '" does not have any data.' );


### PR DESCRIPTION
Fix: Handling of unsupported menu item types in import and export traits

**Export trait customizations:**

- default case added to the switch statement to handle unknown menu item types.
- Output of a warning and skipping of the menu item if the type is not supported.

**Import Trait Customizations:**

- Added check whether the dynamically generated method for the menu item type exists before it is called.
- Skip the menu item if the method does not exist and display an informative message.
- Prevents fatal errors like `Call to undefined method WPB_Import_Menu_Command::get_menu_data_by_wpml_ls_menu_item()`.